### PR TITLE
feat: 주문 상태 변경 로직 추가

### DIFF
--- a/order/urls/booth_urls.py
+++ b/order/urls/booth_urls.py
@@ -4,4 +4,6 @@ from order.views.admin_views import *
 urlpatterns = [
     path("orders/<int:order_id>/", OrderCancelView.as_view(), name="order-cancel"),
     path("orders/", OrderListView.as_view(), name="order-list"),
+    path('kitchen/orders/<int:order_id>/', KitchenOrderCookedView.as_view()),
+    path('serving/orders/<int:order_id>/', ServingOrderCompleteView.as_view()),
 ]


### PR DESCRIPTION
## 🔍 What is the PR?
- 주문 상태 변경 API 구현
- 상태 변경 시 유효성 검사 (이미 서빙됨/조리 안됨 등)


## 📍 PR Point
- 조리/서빙 버튼 하나로 상태 관리 자동화 완료

## 📢 Notices
- 세트메뉴인 경우 OrderSetMenu 기준 정보(menu_name, menu_image, fixed_price)를 응답에 반영
- 프론트는 응답에 따라 단일/세트 구분 없이 UI 출력 가능
- 
## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

#22 