### PR TITLE
feat: 운영자 계좌 정보 카드에서 조회

### DIFF
--- a/cart/urls.py
+++ b/cart/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('cart/detail/', CartDetailView.as_view(), name='cart-detail'),
     path('', CartAddView.as_view(), name='cart-add'),
     path('menu/<int:menu_id>/', CartMenuUpdateView.as_view(), name='cart-menu-update'),
+    path('v2/cart/payment-info/', PaymentInfoView.as_view(), name='payment-info'),
 ]

--- a/cart/views.py
+++ b/cart/views.py
@@ -6,6 +6,7 @@ from cart.models import *
 from cart.serializers import *
 from booth.models import *
 from menu.models import *
+from manager.models import *
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
@@ -219,3 +220,24 @@ class CartMenuUpdateView(APIView):
 
         else:
             return Response({"status": "fail", "message": "type은 menu 또는 set_menu이어야 합니다."}, status=400)
+        
+class PaymentInfoView(APIView):
+    def get(self, request):
+        booth_id = request.headers.get("Booth-ID")
+        if not booth_id:
+            return Response({
+                "status": "fail",
+                "message": "Booth-ID 헤더가 누락되었습니다."
+            }, status=status.HTTP_400_BAD_REQUEST)
+
+        manager = get_object_or_404(Manager, booth_id=booth_id)
+
+        return Response({
+            "status": "success",
+            "code": 200,
+            "data": {
+                "bank_name": manager.bank,
+                "account_number": manager.account,
+                "account_holder": manager.depositor
+            }
+        }, status=status.HTTP_200_OK)


### PR DESCRIPTION
## 🔍 What is the PR?
- 결제 단계에서 계좌 정보 조회 API 구현 (GET /api/v2/cart/payment-info/)
- 계좌 정보는 Booth 모델이 아닌 Manager 모델에서 가져오도록 수정


## 📍 PR Point
- 계좌 정보는 관리자 설정 기반으로 정확히 반환!

## 📢 Notices

- Booth-ID는 모든 요청에서 반드시 헤더로 전달
- 공용 모델인 Manager를 참조할 때는 booth_id 기반으로 get_object_or_404() 사용함

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #31 