### PR TITLE
fix: 테이블 시간 초기화 설정 제거

### DIFF
--- a/cart/views.py
+++ b/cart/views.py
@@ -19,14 +19,12 @@ def _get_manager(booth_id: int):
     return Manager.objects.filter(booth_id=booth_id).first()
 
 def _is_first_session(table: Table, now_dt=None) -> bool:
-    if now_dt is None:
-        now_dt = timezone.now()
-    m = _get_manager(table.booth_id)
-    limit_hours = int(getattr(m, "table_limit_hours", 0) or 0)
+    entered_at = getattr(table, "entered_at", None)
+
     qs = Order.objects.filter(table_id=table.id)
-    if limit_hours > 0:
-        start = now_dt - timezone.timedelta(hours=limit_hours)
-        qs = qs.filter(created_at__gte=start, created_at__lte=now_dt)
+    if entered_at:
+        qs = qs.filter(created_at__gte=entered_at)
+
     return not qs.exists()
 
 def _get_or_create_fee_menu(booth_id: int, seat_mode: str, unit_price: int) -> Menu:


### PR DESCRIPTION
## 🔍 What is the PR?

- table_limit_hours 기반 슬라이딩 윈도우(자동 초기화) 전면 제거
- 입장 시각(Table.entered_at) 기준으로 “첫 주문 여부” 판정 통일

## 📢 Notices

- 시간 경과와 무관하게, 입장 세션만을 기준으로 첫 주문을 판정
- Table.entered_at 값이 입장 시점에 정상 세팅되어야 함 (입장 API에서 entered_at = timezone.now() 보장)

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #65 