### PR TITLE
Feat: WebSocket으로 실시간 주문, 직원 호출 구현

### DIFF
--- a/order/consumers.py
+++ b/order/consumers.py
@@ -1,0 +1,73 @@
+import json
+from channels.generic.websocket import AsyncWebsocketConsumer
+
+# 주문 관련 웹소켓
+class OrderConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+
+        self.room_group_name = "orders"
+
+        await self.channel_layer.group_add(self.room_group_name, self.channel_name)
+        await self.accept()
+
+    async def disconnect(self, close_code):
+        await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
+
+    async def receive(self, text_data):
+        data = json.loads(text_data)
+
+        if data.get("type") == "NEW_ORDER":
+
+            await self.channel_layer.group_send(
+                self.room_group_name,
+                {
+                    "type": "new_order",
+                    "data": {
+                        "orderId": data["data"].get("orderId"),
+                        "tableNumber": data["data"].get("tableNumber"),
+                        "items": data["data"].get("items", []),
+                        "orderTime": data["data"].get("orderTime"),
+                        "status": data["data"].get("status", "ORDER_RECEIVED")
+                    }
+                }
+            )
+
+    async def new_order(self, event):
+        await self.send(text_data=json.dumps({
+            "type": "NEW_ORDER",
+            "data": event["data"]
+        }))
+
+
+# 직원 호출 관련 웹소켓
+class CallStaffConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+
+        self.room_group_name = "staff_calls"
+
+        await self.channel_layer.group_add(self.room_group_name, self.channel_name)
+        await self.accept()
+
+    async def disconnect(self, close_code):
+        await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
+
+    async def receive(self, text_data):
+        data = json.loads(text_data)
+
+        if data.get("type") == "CALL_STAFF":
+
+            await self.channel_layer.group_send(
+                self.room_group_name,
+                {
+                    "type": "staff_call",
+                    "tableNumber": data.get("tableNumber"),
+                    "message": data.get("message", "직원 호출")
+                }
+            )
+
+    async def staff_call(self, event):
+        await self.send(text_data=json.dumps({
+            "type": "CALL_STAFF",
+            "tableNumber": event["tableNumber"],
+            "message": event["message"]
+        }))

--- a/project/routing.py
+++ b/project/routing.py
@@ -1,7 +1,7 @@
 from django.urls import path
-from order import consumers
+from order.consumers import OrderConsumer, CallStaffConsumer
 
 websocket_urlpatterns = [
-    path("ws/orders/<int:table_id>/", consumers.OrderConsumer.as_asgi()),
-    path("ws/call/<int:table_id>/", consumers.CallStaffConsumer.as_asgi()),  # 직원 호출용
+    path("ws/orders/", OrderConsumer.as_asgi()),   # 주문 알림
+    path("ws/call/", CallStaffConsumer.as_asgi()), # 직원 호출
 ]

--- a/project/settings.py
+++ b/project/settings.py
@@ -94,7 +94,6 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'project.wsgi.application'
-
 ASGI_APPLICATION = 'project.asgi.application'
 
 CHANNEL_LAYERS = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ Automat==25.4.16
 cffi==1.17.1
 channels==4.3.0
 channels_redis==4.3.0
+colorama==0.4.6
 constantly==23.10.4
 cryptography==45.0.5
 daphne==4.2.1
@@ -26,6 +27,7 @@ pyasn1_modules==0.4.2
 pycparser==2.22
 PyJWT==2.10.1
 pyOpenSSL==25.1.0
+qrcode==8.2
 redis==6.2.0
 service-identity==24.2.0
 setuptools==80.9.0


### PR DESCRIPTION
## 🔍 What is the PR?

- /ws/orders/ WebSocket API 구현 (NEW_ORDER 이벤트 송수신)
- /ws/call/ WebSocket API 구현 (CALL_STAFF 이벤트 송수신)
- 운영진 → 모든 주문/호출 실시간 수신 가능
- 손님 → tableNumber 기반 이벤트 전송

## 📍 PR Point

- 주문/직원 호출 이벤트 구조를 프론트 요청 예시와 동일하게 맞춤
- 운영진 로그인 상태에서 토큰 기반 WebSocket 연결 가능하도록 준비
- routing.py 분리 → WebSocket 라우팅과 REST API 라우팅 명확히 구분

## 📢 Notices

- WebSocket 연결 시 https 환경에서는 wss:// 프로토콜 사용 필수
- Nginx 설정에서 /ws/ 경로 분리되어 Daphne와 연동됨
- 로컬 테스트 시에는 daphne 실행 후 ws://127.0.0.1:8000 으로 접근 가능

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #79 