### PR TITLE
fix: 웹소켓 오류 쿼리로 변경

### DIFF
--- a/order/consumers.py
+++ b/order/consumers.py
@@ -4,9 +4,12 @@ from channels.generic.websocket import AsyncWebsocketConsumer
 # 주문 관련 웹소켓
 class OrderConsumer(AsyncWebsocketConsumer):
     async def connect(self):
+        user = self.scope.get("user")
+        if not user or not user.is_authenticated:
+            await self.close()
+            return
 
         self.room_group_name = "orders"
-
         await self.channel_layer.group_add(self.room_group_name, self.channel_name)
         await self.accept()
 
@@ -17,7 +20,6 @@ class OrderConsumer(AsyncWebsocketConsumer):
         data = json.loads(text_data)
 
         if data.get("type") == "NEW_ORDER":
-
             await self.channel_layer.group_send(
                 self.room_group_name,
                 {
@@ -39,12 +41,15 @@ class OrderConsumer(AsyncWebsocketConsumer):
         }))
 
 
-# 직원 호출 관련 웹소켓
+# 직원 호출 웹소켓
 class CallStaffConsumer(AsyncWebsocketConsumer):
     async def connect(self):
+        user = self.scope.get("user")
+        if not user or not user.is_authenticated:
+            await self.close()
+            return
 
         self.room_group_name = "staff_calls"
-
         await self.channel_layer.group_add(self.room_group_name, self.channel_name)
         await self.accept()
 
@@ -55,7 +60,6 @@ class CallStaffConsumer(AsyncWebsocketConsumer):
         data = json.loads(text_data)
 
         if data.get("type") == "CALL_STAFF":
-
             await self.channel_layer.group_send(
                 self.room_group_name,
                 {

--- a/project/asgi.py
+++ b/project/asgi.py
@@ -1,8 +1,9 @@
 import os
 import django
 from channels.routing import ProtocolTypeRouter, URLRouter
-from channels.auth import AuthMiddlewareStack
 from django.core.asgi import get_asgi_application
+from channels.auth import AuthMiddlewareStack
+from project.middleware import JWTAuthMiddleware
 import project.routing
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
@@ -10,9 +11,9 @@ django.setup()
 
 application = ProtocolTypeRouter({
     "http": get_asgi_application(),
-    "websocket": AuthMiddlewareStack(
-        URLRouter(
-            project.routing.websocket_urlpatterns
+    "websocket": JWTAuthMiddleware(   # JWT 인증 적용
+        AuthMiddlewareStack(
+            URLRouter(project.routing.websocket_urlpatterns)
         )
     ),
 })

--- a/project/middleware.py
+++ b/project/middleware.py
@@ -1,0 +1,30 @@
+import jwt
+from channels.middleware import BaseMiddleware
+from channels.db import database_sync_to_async
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from urllib.parse import parse_qs
+
+User = get_user_model()
+
+@database_sync_to_async
+def get_user_from_token(token):
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
+        user = User.objects.get(id=payload["user_id"])
+        return user
+    except Exception:
+        return None
+
+class JWTAuthMiddleware(BaseMiddleware):
+    async def __call__(self, scope, receive, send):
+
+        query_string = parse_qs(scope["query_string"].decode())
+        token = query_string.get("token")
+
+        if token:
+            user = await get_user_from_token(token[0])
+            if user:
+                scope["user"] = user
+
+        return await super().__call__(scope, receive, send)


### PR DESCRIPTION
## 🔍 What is the PR?

- consumers.py, routing.py, asgi.py 업데이트
- JWT 토큰을 쿼리 파라미터로 전달받아 운영진 인증 처리 로직 반영

## 📍 PR Point

- WebSocket 연결 시 토큰을 헤더가 아닌 ?token=<JWT> 형태로 전달 → 운영진만 이벤트 수신 가능
- 주문 이벤트(NEW_ORDER)와 직원 호출 이벤트(CALL_STAFF)를 각각 브로드캐스트 그룹으로 분리 처리
- 프론트 요청 형식(JSON)과 응답 형식을 맞춰 표준화

## 📢 Notices

- 운영진 WebSocket 연결 시 반드시 ?token=<JWT> 쿼리 파라미터가 포함되어야 함
- 손님 호출 이벤트의 경우 tableNumber 값은 DB의 Table.table_num과 매칭 검증 필요

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?