### PR TITLE
Feat-Fix: 대시보드 WebSocket 및 직원 호출 POST API 구현

### DIFF
--- a/order/consumers.py
+++ b/order/consumers.py
@@ -1,7 +1,12 @@
 import json
 from channels.generic.websocket import AsyncWebsocketConsumer
+from channels.db import database_sync_to_async
+from booth.models import Table
+from manager.models import Manager
+from django.utils import timezone
+from datetime import timedelta
 
-# 주문 관련 웹소켓
+# 주문 웹소켓
 class OrderConsumer(AsyncWebsocketConsumer):
     async def connect(self):
         user = self.scope.get("user")
@@ -56,22 +61,79 @@ class CallStaffConsumer(AsyncWebsocketConsumer):
     async def disconnect(self, close_code):
         await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
 
-    async def receive(self, text_data):
-        data = json.loads(text_data)
-
-        if data.get("type") == "CALL_STAFF":
-            await self.channel_layer.group_send(
-                self.room_group_name,
-                {
-                    "type": "staff_call",
-                    "tableNumber": data.get("tableNumber"),
-                    "message": data.get("message", "직원 호출")
-                }
-            )
-
+    # receive 제거함. 손님은 REST API로 호출하고 WebSocket은 운영진이 수신만 받는 형식으로 변경
     async def staff_call(self, event):
+        table_num = event["tableNumber"]
+        message = f"{table_num}번 테이블에서 직원을 호출했습니다!"
+
         await self.send(text_data=json.dumps({
             "type": "CALL_STAFF",
-            "tableNumber": event["tableNumber"],
-            "message": event["message"]
+            "tableNumber": table_num,
+            "message": message
         }))
+
+
+# 테이블 상태 조회 함수
+@database_sync_to_async
+def get_table_statuses(user):
+
+    try:
+        manager = Manager.objects.get(user=user)
+        tables = Table.objects.filter(booth=manager.booth)
+
+        result = []
+        for table in tables:
+            remaining_minutes = None
+            is_expired = False
+
+            if table.activated_at:
+                elapsed = timezone.now() - table.activated_at
+                limit = timedelta(hours=manager.table_limit_hours)
+                remaining_minutes = max(0, int((limit - elapsed).total_seconds() // 60))
+                if elapsed > limit:
+                    is_expired = True
+
+            result.append({
+                "tableNumber": table.table_num,
+                "status": table.status,
+                "activatedAt": table.activated_at.isoformat() if table.activated_at else None,
+                "remainingMinutes": remaining_minutes,
+                "expired": is_expired
+            })
+
+        return result
+    except Manager.DoesNotExist:
+        return []
+
+
+# 테이블 상태 대시보드 웹소켓
+class TableStatusConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        user = self.scope.get("user")
+        if not user or not user.is_authenticated:
+            await self.close(code=4001)
+            return
+
+        manager = await database_sync_to_async(Manager.objects.get)(user=user)
+        self.room_group_name = f"booth_{manager.booth.id}_tables"
+
+        await self.channel_layer.group_add(self.room_group_name, self.channel_name)
+        await self.accept()
+        table_statuses = await get_table_statuses(user)
+        await self.send(text_data=json.dumps({
+            "type": "TABLE_STATUS",
+            "data": table_statuses
+        }))
+
+    async def disconnect(self, close_code):
+        await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
+
+    async def receive(self, text_data):
+        data = json.loads(text_data)
+        if data.get("type") == "REFRESH":
+            user = self.scope.get("user")
+            table_statuses = await get_table_statuses(user)
+            await self.send(text_data=json.dumps({
+                "type": "TABLE_STATUS",
+                "data": table_statuses
+            }))

--- a/order/urls/table_urls.py
+++ b/order/urls/table_urls.py
@@ -4,4 +4,5 @@ from order.views.customer_views import *
 urlpatterns = [
     path("orders/order_check/", OrderPasswordVerifyView.as_view()),
     path('<int:table_num>/orders/', TableOrderListView.as_view()),
+    path("call_staff/", CallStaffAPIView.as_view(), name="call-staff"),
 ]

--- a/project/routing.py
+++ b/project/routing.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from order.consumers import OrderConsumer, CallStaffConsumer
+from order.consumers import OrderConsumer, CallStaffConsumer, TableStatusConsumer
 
 websocket_urlpatterns = [
-    path("ws/orders/", OrderConsumer.as_asgi()),   # 주문 알림
-    path("ws/call/", CallStaffConsumer.as_asgi()), # 직원 호출
+    path("ws/orders/", OrderConsumer.as_asgi()),      # 주문 알림
+    path("ws/call/", CallStaffConsumer.as_asgi()),    # 직원 호출
+    path("ws/dashboard/", TableStatusConsumer.as_asgi()),  # 테이블 현황 대시보드
 ]


### PR DESCRIPTION
## 🔍 What is the PR?
- 운영진용 대시보드 WebSocket (TableStatusConsumer) 구현
- 운영진이 실시간으로 테이블 상태(입장 시간, 남은 이용시간, 만료 여부 등)를 확인 가능
- 직원 호출을 위한 손님 측 POST API (/api/v2/tables/call_staff/) 구현
- 손님이 호출 시 WebSocket 그룹(staff_calls)으로 알림 브로드캐스트

## 📍 PR Point
- 손님은 REST API로 호출, 운영진은 WebSocket으로 실시간 알림 수신 → 역할 분리
- 테이블 상태는 부스 단위 그룹(booth_{booth.id}_tables)으로 묶어 다중 매니저 환경도 고려해
- 호출 알림 메시지를 "n번 테이블에서 직원을 호출했습니다!" 형태로 가공하여 전달

## 📢 Notices
- 기존 CallStaffConsumer.receive() 로직 제거 → 혼동 방지 (손님은 REST API만 사용)
- WebSocket 인증은 JWT 쿼리 파라미터(?token=<JWT>) 기반 → 운영진만 접근 가능
- 추후 대시보드 주기적 REFRESH는 클라이언트에서 { "type": "REFRESH" } 메시지 송신으로 처리

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #86 #87 #88 