### PR TITLE
fix: # ORM → async safe 변경 헬퍼 함수 적용

### DIFF
--- a/order/consumers.py
+++ b/order/consumers.py
@@ -4,17 +4,56 @@ from channels.db import database_sync_to_async
 from django.utils import timezone
 from datetime import timedelta
 
+# ORM → async safe 변경
+@database_sync_to_async
+def get_manager_by_user(user):
+    from manager.models import Manager
+    return Manager.objects.get(user=user)
+
+
+@database_sync_to_async
+def get_table_statuses(user):
+    from manager.models import Manager
+    from booth.models import Table
+
+    try:
+        manager = Manager.objects.get(user=user)
+        tables = Table.objects.filter(booth=manager.booth)
+
+        result = []
+        for table in tables:
+            remaining_minutes = None
+            is_expired = False
+
+            if table.activated_at:
+                elapsed = timezone.now() - table.activated_at
+                limit = timedelta(hours=manager.table_limit_hours)
+                remaining_minutes = max(0, int((limit - elapsed).total_seconds() // 60))
+                if elapsed > limit:
+                    is_expired = True
+
+            result.append({
+                "tableNumber": table.table_num,
+                "status": table.status,
+                "activatedAt": table.activated_at.isoformat() if table.activated_at else None,
+                "remainingMinutes": remaining_minutes,
+                "expired": is_expired
+            })
+
+        return result
+    except Manager.DoesNotExist:
+        return []
+
 
 # 주문 웹소켓
 class OrderConsumer(AsyncWebsocketConsumer):
     async def connect(self):
-        from manager.models import Manager
         user = self.scope.get("user")
         if not user or not user.is_authenticated:
             await self.close()
             return
 
-        manager = await database_sync_to_async(Manager.objects.get)(user=user)
+        manager = await get_manager_by_user(user)
         self.room_group_name = f"booth_{manager.booth.id}_orders"
 
         await self.channel_layer.group_add(self.room_group_name, self.channel_name)
@@ -52,14 +91,13 @@ class OrderConsumer(AsyncWebsocketConsumer):
 # 직원 호출 웹소켓
 class CallStaffConsumer(AsyncWebsocketConsumer):
     async def connect(self):
-        from manager.models import Manager
         user = self.scope.get("user")
         if not user or not user.is_authenticated:
             await self.close()
             return
 
-        manager = await database_sync_to_async(Manager.objects.get)(user=user)
-        self.room_group_name = f"booth_{manager.booth.id}_staff_calls" 
+        manager = await get_manager_by_user(user)
+        self.room_group_name = f"booth_{manager.booth.id}_staff_calls"
 
         await self.channel_layer.group_add(self.room_group_name, self.channel_name)
         await self.accept()
@@ -67,7 +105,6 @@ class CallStaffConsumer(AsyncWebsocketConsumer):
     async def disconnect(self, close_code):
         await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
 
-    # 손님은 REST API로 호출 → 운영진 WebSocket이 수신
     async def staff_call(self, event):
         table_num = event["tableNumber"]
         message = f"{table_num}번 테이블에서 직원을 호출했습니다!"
@@ -80,54 +117,20 @@ class CallStaffConsumer(AsyncWebsocketConsumer):
         }))
 
 
-# 테이블 상태 조회 함수
-@database_sync_to_async
-def get_table_statuses(user):
-    from manager.models import Manager
-    from booth.models import Table
-    try:
-        manager = Manager.objects.get(user=user)
-        tables = Table.objects.filter(booth=manager.booth)
-
-        result = []
-        for table in tables:
-            remaining_minutes = None
-            is_expired = False
-
-            if table.activated_at:
-                elapsed = timezone.now() - table.activated_at
-                limit = timedelta(hours=manager.table_limit_hours)
-                remaining_minutes = max(0, int((limit - elapsed).total_seconds() // 60))
-                if elapsed > limit:
-                    is_expired = True
-
-            result.append({
-                "tableNumber": table.table_num,
-                "status": table.status,
-                "activatedAt": table.activated_at.isoformat() if table.activated_at else None,
-                "remainingMinutes": remaining_minutes,
-                "expired": is_expired
-            })
-
-        return result
-    except Manager.DoesNotExist:
-        return []
-
-
 # 테이블 상태 대시보드 웹소켓
 class TableStatusConsumer(AsyncWebsocketConsumer):
     async def connect(self):
-        from manager.models import Manager
         user = self.scope.get("user")
         if not user or not user.is_authenticated:
             await self.close(code=4001)
             return
 
-        manager = await database_sync_to_async(Manager.objects.get)(user=user)
+        manager = await get_manager_by_user(user)
         self.room_group_name = f"booth_{manager.booth.id}_tables"
 
         await self.channel_layer.group_add(self.room_group_name, self.channel_name)
         await self.accept()
+
         table_statuses = await get_table_statuses(user)
         await self.send(text_data=json.dumps({
             "type": "TABLE_STATUS",


### PR DESCRIPTION
## 🔍 What is the PR?

- consumers.py 전반에 걸쳐 ORM 호출을 @database_sync_to_async 로 감싸 비동기 안전 처리
- Manager, Table 모델 import 시 lazy import 방식 적용 → Django 앱 초기화 단계 문제 방지
- 주문/직원호출/테이블 상태 웹소켓을 부스별 그룹 네이밍(booth_{id}_...)으로 확실히 분리
- CallStaffAPIView 에서도 booth_id 기준으로 group_send 되도록 로직 보완

## 📍 PR Point

- 핵심: 부스별 WebSocket 그룹 매핑 확실히 분리 → 여러 부스에서 동시에 호출해도 충돌 없이 알림 전달됨
- Django ORM 비동기 호출 오류(SynchronousOnlyOperation) 해결 → 안정적으로 연결 유지 가능
- import 순서로 인한 AppRegistryNotReady 문제 방지

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #87 