### PR TITLE
Feat: 실시간 주문 구현

### DIFF
--- a/order/views/admin_views.py
+++ b/order/views/admin_views.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 from rest_framework.status import (
     HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 )
+from order.utils.order_broadcast import broadcast_order_update
 
 from order.models import *
 from cart.models import *
@@ -18,6 +19,7 @@ from menu.models import *
 from booth.models import *
 from manager.models import *
 from order.serializers import *
+from order.utils.order_broadcast import broadcast_order_update
 
 SEAT_MENU_CATEGORY = "seat"
 SEAT_FEE_CATEGORY = "seat_fee"
@@ -56,10 +58,10 @@ class OrderListView(APIView):
         menu_filter = (request.GET.get("menu") or "").strip().lower()
         category_filter = (request.GET.get("category") or "").strip().lower()
 
-        # ✅ 부스 내 모든 주문
+        # 부스 내 모든 주문
         order_query = Order.objects.filter(table__booth_id=booth_id)
 
-        # ✅ 각 테이블의 활성화 이후 주문만 필터링
+        # 각 테이블의 활성화 이후 주문만 필터링
         valid_orders = []
         for table in Table.objects.filter(booth_id=booth_id):
             activated_at = getattr(table, "activated_at", None)
@@ -71,29 +73,27 @@ class OrderListView(APIView):
         total_revenue = booth.total_revenues
         expanded = []
 
-    
         for order in valid_orders:
-            # ✅ 일반 메뉴
+            # 일반 메뉴
             for om in OrderMenu.objects.filter(order=order).select_related("menu", "ordersetmenu__set_menu"):
                 if om.menu.menu_category == SEAT_FEE_CATEGORY:
-                    continue  # 🚨 seat_fee 제외
+                    continue  # seat_fee 제외
                 
-                # 🚨 type 필터는 order_status 대신 menu.status 사용
+                # type 필터는 order_status 대신 menu.status 사용
                 if type_param == "kitchen" and om.status not in ["pending", "cooked"]:
                     continue
                 if type_param == "serving" and om.status not in ["cooked", "served"]:
                     continue
                 
                 expanded.append({
-                    "id": om.id,
+                    "order_item_id": om.id,   ### 수정: 혼동 줄이도록 order_item_id 사용
                     "order_id": om.order_id,
                     "menu_id": om.menu_id,
                     "menu_name": om.menu.menu_name,
                     "menu_price": float(om.menu.menu_price),
                     "fixed_price": om.fixed_price,
                     "quantity": om.quantity,
-                    "status": om.status,  # ✅ 개별 메뉴 상태
-                    # "order_status": om.order.order_status,
+                    "status": om.status,  # 개별 메뉴 상태
                     "created_at": om.order.created_at.isoformat(),
                     "updated_at": om.order.updated_at.isoformat(),
                     "order_amount": om.order.order_amount,
@@ -104,7 +104,6 @@ class OrderListView(APIView):
                     "set_id": om.ordersetmenu_id,
                     "set_name": om.ordersetmenu.set_menu.set_name if om.ordersetmenu else None,
                 })
-
 
         if menu_filter or category_filter:
             def _match(row):
@@ -127,7 +126,6 @@ class OrderListView(APIView):
                 "orders": expanded
             }
         }, status=200)
- 
 
         
 class OrderCancelView(APIView):
@@ -136,7 +134,7 @@ class OrderCancelView(APIView):
     PATCH /orders/<order_id>/cancel/
     """
 
-    permission_classes = [IsAuthenticated]  # 필요 시 관리자 인증 붙이기
+    permission_classes = [IsAuthenticated]
 
     def patch(self, request, order_id):
         booth_id = request.headers.get("Booth-ID")
@@ -165,20 +163,15 @@ class OrderCancelView(APIView):
                     order_item_id = item["order_item_id"]
                     cancel_qty = item["quantity"]
 
-                    # 1️⃣ OrderMenu 취소
+                    # OrderMenu 취소
                     om = OrderMenu.objects.filter(pk=order_item_id, order=order).first()
                     if om:
-                        # quantity=0 → 전체 취소 처리
                         if cancel_qty == 0:
                             cancel_qty = om.quantity
-
                         if cancel_qty > om.quantity:
                             return Response(
-                                {
-                                    "status": "error",
-                                    "code": 400,
-                                    "message": f"취소 수량({cancel_qty})이 주문 수량({om.quantity})을 초과합니다.",
-                                },
+                                {"status": "error", "code": 400,
+                                "message": f"취소 수량({cancel_qty})이 주문 수량({om.quantity})을 초과합니다."},
                                 status=HTTP_400_BAD_REQUEST,
                             )
 
@@ -190,39 +183,30 @@ class OrderCancelView(APIView):
                         refund_amount = om.fixed_price * cancel_qty
                         total_refund += refund_amount
 
-                        # 주문 수량 차감 or 삭제
                         om.quantity -= cancel_qty
                         if om.quantity == 0:
                             om.delete()
                         else:
                             om.save()
 
-                        updated_items.append(
-                            {
-                                "order_menu_id": order_item_id,
-                                "menu_name": menu.menu_name,
-                                "rest_quantity": om.quantity if om.id else 0,
-                                "restored_stock": cancel_qty,
-                                "refund": refund_amount,
-                            }
-                        )
+                        updated_items.append({
+                            "order_menu_id": order_item_id,
+                            "menu_name": menu.menu_name,
+                            "rest_quantity": om.quantity if om.id else 0,
+                            "restored_stock": cancel_qty,
+                            "refund": refund_amount,
+                        })
                         continue
 
-                    # 2️⃣ OrderSetMenu 취소
-                    osm = OrderSetMenu.objects.filter(
-                        pk=order_item_id, order=order
-                    ).first()
+                    # OrderSetMenu 취소
+                    osm = OrderSetMenu.objects.filter(pk=order_item_id, order=order).first()
                     if osm:
                         if cancel_qty == 0:
                             cancel_qty = osm.quantity
-
                         if cancel_qty > osm.quantity:
                             return Response(
-                                {
-                                    "status": "error",
-                                    "code": 400,
-                                    "message": f"취소 수량({cancel_qty})이 세트 수량({osm.quantity})을 초과합니다.",
-                                },
+                                {"status": "error", "code": 400,
+                                "message": f"취소 수량({cancel_qty})이 세트 수량({osm.quantity})을 초과합니다."},
                                 status=HTTP_400_BAD_REQUEST,
                             )
 
@@ -235,43 +219,41 @@ class OrderCancelView(APIView):
                             si.menu.menu_amount += restore_qty
                             si.menu.save()
 
-                        # 세트 수량 차감 or 삭제
                         osm.quantity -= cancel_qty
                         if osm.quantity == 0:
                             osm.delete()
                         else:
                             osm.save()
 
-                        updated_items.append(
-                            {
-                                "order_setmenu_id": order_item_id,
-                                "set_name": osm.set_menu.set_name,
-                                "rest_quantity": osm.quantity if osm.id else 0,
-                                "restored_stock": cancel_qty,
-                                "refund": refund_amount,
-                            }
-                        )
+                        updated_items.append({
+                            "order_setmenu_id": order_item_id,
+                            "set_name": osm.set_menu.set_name,
+                            "rest_quantity": osm.quantity if osm.id else 0,
+                            "restored_stock": cancel_qty,
+                            "refund": refund_amount,
+                        })
                         continue
 
                     return Response(
-                        {
-                            "status": "error",
-                            "code": 404,
-                            "message": f"order_item_id {order_item_id}에 해당하는 주문 항목을 찾을 수 없습니다.",
-                        },
+                        {"status": "error", "code": 404,
+                        "message": f"order_item_id {order_item_id}에 해당하는 주문 항목을 찾을 수 없습니다."},
                         status=HTTP_404_NOT_FOUND,
                     )
 
-                # 3️⃣ 주문 총액, 부스 매출 차감
+                # 주문 총액, 부스 매출 차감
                 order.order_amount = max(order.order_amount - total_refund, 0)
                 order.save()
 
                 booth = order.table.booth
                 booth.total_revenues = max((booth.total_revenues or 0) - total_refund, 0)
                 booth.save()
-                
+
+                # 통계 push
                 from statistic.utils import push_statistics
                 push_statistics(booth.id)
+
+                # 주문 취소 후 운영자 페이지에 실시간 전송
+                broadcast_order_update(order)
 
                 return Response(
                     {
@@ -291,19 +273,17 @@ class OrderCancelView(APIView):
 
         except Exception as e:
             import traceback
-
             traceback.print_exc()
             return Response(
                 {"status": "error", "code": 500, "message": str(e)}, status=500
             )
-  
+
 class KitchenOrderCookedView(APIView):
     """
     POST /api/v2/kitchen/orders/
-    요청 body:
     {
         "type": "menu" | "setmenu",
-        "id": <ordermenu_id or ordersetmenu_id>
+        "id": <order_item_id>
     }
     """
     permission_classes = [IsAuthenticated]
@@ -313,54 +293,51 @@ class KitchenOrderCookedView(APIView):
         item_id = request.data.get("id")
 
         if item_type not in ["menu", "setmenu"] or not item_id:
-            return Response({
-                "status": "error",
-                "code": 400,
-                "message": "type은 menu 또는 setmenu이고 id는 필수입니다."
-            }, status=400)
+            return Response(
+                {"status": "error", "code": 400, "message": "type(menu|setmenu), id 필수"},
+                status=400
+            )
 
         if item_type == "menu":
             obj = get_object_or_404(OrderMenu, pk=item_id)
             if obj.status != "pending":
-                return Response({
-                    "status": "error",
-                    "code": 400,
-                    "message": "대기 상태가 아닌 메뉴는 조리 완료할 수 없습니다."
-                }, status=400)
+                return Response(
+                    {"status": "error", "code": 400, "message": "대기 상태가 아닌 메뉴는 조리 완료 불가"},
+                    status=400
+                )
 
             obj.status = "cooked"
             obj.save(update_fields=["status"])
 
-            # ✅ 세트 동기화
+            # 세트 동기화
             if obj.ordersetmenu_id:
                 setmenu = obj.ordersetmenu
-                child_statuses = OrderMenu.objects.filter(
+                statuses = OrderMenu.objects.filter(
                     ordersetmenu=setmenu
                 ).values_list("status", flat=True)
 
-                if all(s == "cooked" for s in child_statuses):
+                if all(s == "cooked" for s in statuses):
                     setmenu.status = "cooked"
-                elif any(s == "pending" for s in child_statuses):
+                elif any(s == "pending" for s in statuses):
                     setmenu.status = "pending"
                 setmenu.save(update_fields=["status"])
 
         else:  # setmenu
             obj = get_object_or_404(OrderSetMenu, pk=item_id)
             if obj.status != "pending":
-                return Response({
-                    "status": "error",
-                    "code": 400,
-                    "message": "대기 상태가 아닌 세트는 조리 완료할 수 없습니다."
-                }, status=400)
+                return Response(
+                    {"status": "error", "code": 400, "message": "대기 상태가 아닌 세트는 조리 완료 불가"},
+                    status=400
+                )
 
             obj.status = "cooked"
             obj.save(update_fields=["status"])
 
-        # ✅ Serializer
-        if isinstance(obj, OrderMenu):
-            data = OrderMenuSerializer(obj).data
-        else:
-            data = OrderSetMenuSerializer(obj).data
+        # 직렬화 (중복 제거)
+        data = OrderMenuSerializer(obj).data if isinstance(obj, OrderMenu) else OrderSetMenuSerializer(obj).data
+
+        # 조리 상태 변경 → 모든 페이지 동기화 필요
+        broadcast_order_update(obj.order)
 
         return Response({"status": "success", "code": 200, "data": data}, status=200)
 
@@ -371,7 +348,7 @@ class ServingOrderCompleteView(APIView):
     요청 body:
     {
         "type": "menu" | "setmenu",
-        "id": <ordermenu_id or ordersetmenu_id>
+        "id": <order_item_id>
     }
     """
     permission_classes = [IsAuthenticated]
@@ -381,25 +358,23 @@ class ServingOrderCompleteView(APIView):
         item_id = request.data.get("id")
 
         if item_type not in ["menu", "setmenu"] or not item_id:
-            return Response({
-                "status": "error",
-                "code": 400,
-                "message": "type은 menu 또는 setmenu이고 id는 필수입니다."
-            }, status=400)
+            return Response(
+                {"status": "error", "code": 400, "message": "type은 menu 또는 setmenu이고 id는 필수입니다."},
+                status=400
+            )
 
         if item_type == "menu":
             obj = get_object_or_404(OrderMenu, pk=item_id)
             if obj.status != "cooked":
-                return Response({
-                    "status": "error",
-                    "code": 400,
-                    "message": "조리 완료 상태가 아닌 메뉴는 서빙 완료할 수 없습니다."
-                }, status=400)
+                return Response(
+                    {"status": "error", "code": 400, "message": "조리 완료 상태가 아닌 메뉴는 서빙 완료할 수 없습니다."},
+                    status=400
+                )
 
             obj.status = "served"
             obj.save(update_fields=["status"])
 
-            # ✅ 세트 동기화
+            # 세트 동기화
             if obj.ordersetmenu_id:
                 setmenu = obj.ordersetmenu
                 child_statuses = OrderMenu.objects.filter(
@@ -417,29 +392,27 @@ class ServingOrderCompleteView(APIView):
         else:  # setmenu
             obj = get_object_or_404(OrderSetMenu, pk=item_id)
             if obj.status != "cooked":
-                return Response({
-                    "status": "error",
-                    "code": 400,
-                    "message": "조리 완료 상태가 아닌 세트는 서빙 완료할 수 없습니다."
-                }, status=400)
+                return Response(
+                    {"status": "error", "code": 400, "message": "조리 완료 상태가 아닌 세트는 서빙 완료할 수 없습니다."},
+                    status=400
+                )
 
             obj.status = "served"
             obj.save(update_fields=["status"])
 
-        # ✅ Serializer
-        if isinstance(obj, OrderMenu):
-            data = OrderMenuSerializer(obj).data
-        else:
-            data = OrderSetMenuSerializer(obj).data
+        # 직렬화 (중복 제거)
+        data = OrderMenuSerializer(obj).data if isinstance(obj, OrderMenu) else OrderSetMenuSerializer(obj).data
+
+        # 상태 변경 → 모든 페이지 동기화 필요
+        broadcast_order_update(obj.order)
 
         return Response({"status": "success", "code": 200, "data": data}, status=200)
 
 
+
 class OrderRevertStatusView(APIView):
     """
-    주문 상태 되돌리기 API (항목 단위)
     PATCH /api/v2/orders/revert-status/
-    요청 body:
     {
         "id": <ordermenu_id>,
         "target_status": "pending" | "cooked"
@@ -452,56 +425,47 @@ class OrderRevertStatusView(APIView):
         target_status = request.data.get("target_status")
 
         if not item_id or target_status not in ["pending", "cooked"]:
-            return Response({
-                "status": "error",
-                "code": 400,
-                "message": "id와 target_status(pending|cooked)는 필수입니다."
-            }, status=400)
+            return Response({"status": "error", "code": 400,
+                            "message": "id, target_status(pending|cooked) 필수"}, status=400)
 
         obj = OrderMenu.objects.filter(pk=item_id).first()
         if not obj:
-            return Response({
-                "status": "error",
-                "code": 404,
-                "message": f"OrderMenu {item_id}를 찾을 수 없습니다."
-            }, status=404)
+            return Response({"status": "error", "code": 404,
+                            "message": f"OrderMenu {item_id} 찾을 수 없음"}, status=404)
 
         prev_status = obj.status
-
-        # 🚨 허용되는 되돌리기 규칙
         allowed = {"cooked": "pending", "served": "cooked"}
 
         if prev_status not in allowed or allowed[prev_status] != target_status:
-            return Response({
-                "status": "error",
-                "code": 400,
-                "message": f"{prev_status} 상태에서는 {target_status} 로 되돌릴 수 없습니다."
-            }, status=400)
+            return Response({"status": "error", "code": 400,
+                            "message": f"{prev_status} → {target_status} 되돌리기 불가"}, status=400)
 
         obj.status = target_status
         obj.save(update_fields=["status"])
 
-        # ✅ 세트 동기화
+        # 세트 동기화
         if obj.ordersetmenu_id:
             setmenu = obj.ordersetmenu
-            child_statuses = OrderMenu.objects.filter(
-                ordersetmenu=setmenu
-            ).values_list("status", flat=True)
-
-            if all(s == "cooked" for s in child_statuses):
+            statuses = OrderMenu.objects.filter(
+                ordersetmenu=setmenu).values_list("status", flat=True)
+            if all(s == "cooked" for s in statuses):
                 setmenu.status = "cooked"
-            elif all(s == "served" for s in child_statuses):
+            elif all(s == "served" for s in statuses):
                 setmenu.status = "served"
             else:
                 setmenu.status = "pending"
             setmenu.save(update_fields=["status"])
 
+        # 되돌리기 → 전체 broadcast
+        broadcast_order_update(obj.order)
+
+        ### 수정: 되돌리기 시 재고 변경 없음 (정책 그대로 유지)
         return Response({
             "status": "success",
             "code": 200,
-            "message": f"항목 상태가 {prev_status} → {target_status} 로 되돌려졌습니다.",
+            "message": f"{prev_status} → {target_status} 변경됨",
             "data": {
-                "ordermenu_id": obj.id,
+                "order_item_id": obj.id,   ### 수정: 필드명 통일
                 "prev_status": prev_status,
                 "new_status": target_status
             }


### PR DESCRIPTION
## 🔍 What is the PR?

- 주문 생성 시 WebSocket 브로드캐스트 로직 추가
- 주문 취소, 조리 완료, 서빙 완료, 상태 되돌리기 시 운영자 페이지에 실시간 반영되도록 수정
- 중복된 직렬화(data = …) 코드 정리
- order_item_id 네이밍 정리 (단품/세트 혼동 최소화)
- seat_fee(테이블/인당 요금) 메뉴는 운영자 화면에서 제외 처리
- 취소 시 통계 반영(`push_statistics`) 보강

## 📍 PR Point

- 나 이 부분 찢었다~!  
  → 주문 라이프사이클 전체(생성~취소~조리~서빙~되돌리기)에 실시간 동기화 적용해서 프론트/운영자 페이지가 항상 최신 상태를 볼 수 있도록 개선함.

## 📢 Notices

- 공용으로 사용하는 `broadcast_order_update`를 각 단계에서 호출하도록 확장했음.  
- 모델 필드는 건드리지 않았지만, `order_status`는 여전히 쓰이지 않음 → 추후 일관성 정리 필요.

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가? (feature/my-fix → dev)
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #160 