### PR TITLE
fix: 실시간 주문 ORDER_UPDATE 로직 변경

### DIFF
--- a/order/utils/order_broadcast.py
+++ b/order/utils/order_broadcast.py
@@ -15,12 +15,16 @@ def expand_order(order: Order):
     for om in order_menus:
         if om.menu.menu_category not in VISIBLE_MENU_CATEGORIES:
             continue
-        # 서빙 완료 후 10초 지난 건 제외
         if om.status == "served" and om.updated_at <= now() - timedelta(seconds=60):
             continue
 
-        # 여기서 음료일 경우 status 강제로 cooked 처리
-        status = "cooked" if om.menu.menu_category == "음료" else om.status
+        # ✅ served는 그대로 두고, 그 외 음료만 cooked 강제 처리
+        if om.status == "served":
+            status = "served"
+        elif om.menu.menu_category == "음료":
+            status = "cooked"
+        else:
+            status = om.status
 
         expanded.append({
             "ordermenu_id": om.id,
@@ -29,7 +33,7 @@ def expand_order(order: Order):
             "menu_name": om.menu.menu_name,
             "menu_image": om.menu.menu_image.url if om.menu.menu_image else None,
             "quantity": om.quantity,
-            "status": status,   # 수정된 status 적용
+            "status": status,
             "created_at": om.order.created_at.isoformat(),
             "table_num": om.order.table.table_num,
             "from_set": False,
@@ -49,17 +53,22 @@ def expand_order(order: Order):
             if om.status == "served" and om.updated_at <= now() - timedelta(seconds=60):
                 continue
 
-            # 세트 구성품도 음료면 cooked 처리
-            status = "cooked" if om.menu.menu_category == "음료" else om.status
+            # ✅ 세트 구성품도 동일하게 처리
+            if om.status == "served":
+                status = "served"
+            elif om.menu.menu_category == "음료":
+                status = "cooked"
+            else:
+                status = om.status
 
             expanded.append({
-                "ordermenu_id": om.id,   # 세트 구성도 OrderMenu 기준으로
+                "ordermenu_id": om.id,
                 "order_id": om.order_id,
                 "menu_id": om.menu_id,
                 "menu_name": om.menu.menu_name,
                 "menu_image": om.menu.menu_image.url if om.menu.menu_image else None,
                 "quantity": om.quantity,
-                "status": status,   # 수정된 status 적용
+                "status": status,
                 "created_at": om.order.created_at.isoformat(),
                 "table_num": om.order.table.table_num,
                 "from_set": True,
@@ -68,6 +77,63 @@ def expand_order(order: Order):
             })
 
     return expanded
+
+
+# ✅ 새로 추가: 단건 OrderMenu broadcast
+def broadcast_order_item_update(ordermenu: OrderMenu):
+    booth = ordermenu.order.table.booth
+    channel_layer = get_channel_layer()
+
+    data = {
+        "ordermenu_id": ordermenu.id,
+        "order_id": ordermenu.order.id,
+        "menu_id": ordermenu.menu.id,
+        "menu_name": ordermenu.menu.menu_name,
+        "menu_image": ordermenu.menu.menu_image.url if ordermenu.menu.menu_image else None,
+        "quantity": ordermenu.quantity,
+        "status": ordermenu.status,
+        "created_at": ordermenu.order.created_at.isoformat(),
+        "table_num": ordermenu.order.table.table_num,
+        "from_set": ordermenu.ordersetmenu_id is not None,
+        "set_id": ordermenu.ordersetmenu_id,
+        "set_name": (
+            ordermenu.ordersetmenu.set_menu.set_name if ordermenu.ordersetmenu else None
+        ),
+    }
+
+    async_to_sync(channel_layer.group_send)(
+        f"booth_{booth.id}_orders",
+        {
+            "type": "order_update",
+            "data": data,   # 단건만 push
+        }
+    )
+
+
+# ✅ 새로 추가: 단건 OrderSetMenu broadcast
+def broadcast_order_set_update(orderset: OrderSetMenu):
+    booth = orderset.order.table.booth
+    channel_layer = get_channel_layer()
+
+    data = {
+        "ordersetmenu_id": orderset.id,
+        "order_id": orderset.order.id,
+        "set_name": orderset.set_menu.set_name,
+        "set_id": orderset.set_menu.id,
+        "quantity": orderset.quantity,
+        "status": orderset.status,
+        "created_at": orderset.order.created_at.isoformat(),
+        "table_num": orderset.order.table.table_num,
+    }
+
+    async_to_sync(channel_layer.group_send)(
+        f"booth_{booth.id}_orders",
+        {
+            "type": "order_update",
+            "data": data,   # 세트 단건 push
+        }
+    )
+
 
 def broadcast_order_update(order: Order):
     booth = order.table.booth
@@ -86,16 +152,14 @@ def broadcast_order_update(order: Order):
         }
     )
     
+
 def broadcast_total_revenue(booth_id: int, total_revenue):
-    """
-    총매출만 따로 브로드캐스트
-    """
     channel_layer = get_channel_layer()
     async_to_sync(channel_layer.group_send)(
         f"booth_{booth_id}_revenue",
         {
             "type": "revenue_update",
             "boothId": int(booth_id),
-            "totalRevenue": int(total_revenue or 0),  # Decimal → int 변환
+            "totalRevenue": int(total_revenue or 0),
         }
     )


### PR DESCRIPTION
## 🔍 What is the PR?

- 실시간 주문 ORDER_UPDATE 로직 변경
- order_id 묶어서 보내지 않고 변경 사항엔 단일 오브젝트만 포함하게 함

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- 작업한 이슈번호를 # 뒤에 붙여주세요. 

- ex) #3 -->