### PR TITLE
fix: 서빙완료시 order_id 매핑

### DIFF
--- a/order/consumers.py
+++ b/order/consumers.py
@@ -150,6 +150,13 @@ class OrderConsumer(AsyncWebsocketConsumer):
             "type": "ORDER_UPDATE",
             "data": event["data"]
         }))
+        
+    # 새로 추가: 빌지 단위 완료 이벤트
+    async def order_completed(self, event):
+        await self.send(text_data=json.dumps({
+            "type": "ORDER_COMPLETED",
+            "data": event["data"]   # { order_id, table_num }
+        }))
 
 
 

--- a/order/utils/order_broadcast.py
+++ b/order/utils/order_broadcast.py
@@ -192,3 +192,19 @@ def broadcast_total_revenue(booth_id: int, total_revenue):
             "totalRevenue": int(total_revenue or 0),
         }
     )
+
+# 새로 추가: 빌지 전체 완료 시 broadcast
+def broadcast_order_completed(order: Order):
+    booth = order.table.booth
+    channel_layer = get_channel_layer()
+
+    async_to_sync(channel_layer.group_send)(
+        f"booth_{booth.id}_orders",
+        {
+            "type": "order_completed",
+            "data": {
+                "order_id": order.id,
+                "table_num": order.table.table_num,
+            }
+        }
+    )


### PR DESCRIPTION
## 🔍 What is the PR?

- WS 실시간 주문시 서빙완료한 order_id를 그룹핑하여 삭제 처리하는 로직 추가

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
