### PR TITLE
fix: 주문 웹소켓 API 수정/ 주문취소 및 5분 지연 요청 로직 추가

### DIFF
--- a/order/consumers.py
+++ b/order/consumers.py
@@ -157,6 +157,13 @@ class OrderConsumer(AsyncWebsocketConsumer):
             "type": "ORDER_COMPLETED",
             "data": event["data"]   # { order_id, table_num }
         }))
+        
+    async def order_cancelled(self, event):
+        await self.send(text_data=json.dumps({
+            "type": "ORDER_CANCELLED",
+            "data": event["data"]
+        }))
+
 
 
 


### PR DESCRIPTION
## 🔍 What is the PR?

- 주문 취소(OrderCancelView) 로직 개선
- `ORDER_CANCELLED` WebSocket 이벤트 추가
- `ORDER_COMPLETED` 이벤트에 `served_at` 필드 추가
- OrderList API에서 served 후 5분 경과 항목 제외 처리
- 방송/응답 구조 통일 (`updated_items`, `skipped_items`)

## 📍 PR Point

- 주문 취소 후 REST + WS 동기화 처리 완성
- 프론트가 더 직관적으로 처리할 수 있게 이벤트 타입/데이터 명확화
- `served_at` 기준으로 UI/백엔드 모두 동일한 5분 지연 삭제 로직 적용

## 📢 Notices

- 공용 `order_broadcast.py`에 `broadcast_order_cancelled`, `broadcast_order_completed` 수정 사항이 있음  
- 다른 API(view)에서도 공용 브로드캐스트 함수 사용 가능하니 확인 필요

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?